### PR TITLE
Filter elements with no id for Docsify Search

### DIFF
--- a/dist/toc.js
+++ b/dist/toc.js
@@ -90,7 +90,7 @@ var buildTOC = function(options) {
   var wrapper = ret;
   var lastLi = null;
   var selector = options.scope + ' ' + options.headings
-  var headers = getHeaders(selector)
+  var headers = getHeaders(selector).filter(h => h.id);
 
   headers.reduce(function(prev, curr, index) {
     var currentLevel = getLevel(curr.tagName);


### PR DESCRIPTION
When using docsify search and clicking on a specific search result, the ToC does not get updated and we get an error in the console "appendChild" for the wrapper element on createList function.
This error was triggered because the plugin was pulling more elements than needed. The filter solves the issue.