### PR TITLE
Fix anchors with <code> element

### DIFF
--- a/dist/toc.css
+++ b/dist/toc.css
@@ -25,6 +25,10 @@ aside.nav.nothing {
   padding-left: 5px;
 }
 
+.page_toc a > * {
+  pointer-events: none;
+}
+
 .page_toc code {
   background-color: #f8f8f8;
   border-radius: 2px;

--- a/dist/toc.js
+++ b/dist/toc.js
@@ -39,7 +39,7 @@ var tocClick = function(e) {
   });
 
   // Make sure this is attached to the parent not itself
-  e.target.parentNode.setAttribute('class', 'active')
+  e.currentTarget.setAttribute('class', 'active')
 };
 
 var createList = function(wrapper, count) {


### PR DESCRIPTION
This plugin is used on [qmk's documentation page](https://docs.qmk.fm/). Somone [found out](https://github.com/qmk/qmk_firmware/issues/10300) that links doesn't work when elements have \<code\> tag. 

I came up with [solution](https://github.com/qmk/qmk_firmware/pull/15169), copied plugin to qmk codebase and patched it, but project members wants to fix this on upstream.

[Page where problem occurs](https://docs.qmk.fm/#/cli_commands)